### PR TITLE
Resolves issue #10

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,16 @@
         "php": ">=5.3.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.*"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
-        "psr-0": {
-            "Treffynnon\\At": "lib"
+        "psr-4": {
+            "Treffynnon\\At\\": "lib/Treffynnon/At"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Treffynnon\\At\\Tests\\": "tests/Treffynnon/At"
         }
     }
 }

--- a/lib/Treffynnon/At/JobAddException.php
+++ b/lib/Treffynnon/At/JobAddException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Treffynnon\At;
+/**
+ * Triggered when the addition of a job to the queue has failed.
+ */
+class JobAddException extends \Exception {}

--- a/lib/Treffynnon/At/JobNotFoundException.php
+++ b/lib/Treffynnon/At/JobNotFoundException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Treffynnon\At;
+/**
+ * Triggered when a job cannot be found in the queue
+ */
+class JobNotFoundException extends \Exception {}

--- a/lib/Treffynnon/At/UndefinedPropertyException.php
+++ b/lib/Treffynnon/At/UndefinedPropertyException.php
@@ -1,0 +1,7 @@
+<?php
+namespace Treffynnon\At;
+/**
+ * Triggered when attempting to access class property that has not yet been
+ * defined.
+ */
+class UndefinedPropertyException extends \Exception {}

--- a/lib/Treffynnon/At/Wrapper.php
+++ b/lib/Treffynnon/At/Wrapper.php
@@ -14,7 +14,7 @@ class Wrapper {
      * @var string
      */
     protected static $binary = 'at';
-    
+
     /**
      * Regular expression to get the details of a job from the add job response
      * @var string
@@ -59,7 +59,7 @@ class Wrapper {
      * of interaction with `at`. I think it is also the safest way of
      * accommodating users who do not the have the problem of warning being
      * triggered when adding a new job.
-     * 
+     *
      * @var string
      */
     protected static $pipeTo = '2>&1';
@@ -191,7 +191,7 @@ class Wrapper {
 
         $map = $type .'Map';
         $map = self::$$map;
-        
+
         foreach($output_array as $line) {
             $matches = array();
             preg_match($regex, $line, $matches);
@@ -260,7 +260,7 @@ class Job {
      * Magic method to set a value in the $data
      * property of the class
      * @param string $name
-     * @param mixed $value 
+     * @param mixed $value
      */
     public function __set($name, $value) {
         $this->data[$name] = $value;
@@ -298,7 +298,7 @@ class Job {
     /**
      * Magic method to unset an index in the $data property
      * of the class
-     * @param string $name 
+     * @param string $name
      */
     public function __unset($name) {
         unset($this->data[$name]);
@@ -320,7 +320,7 @@ class Job {
             Wrapper::removeJob((int)$this->job_number);
         }
     }
-    
+
     /**
      * Get a DateTime object for date and time extracted from
      * the output of `at`
@@ -332,19 +332,3 @@ class Job {
         return new \DateTime($this->date);
     }
 }
-
-/**
- * Triggered when attempting to access class property that has not yet been
- * defined.
- */
-class UndefinedPropertyException extends \Exception {}
-
-/**
- * Triggered when the addition of a job to the queue has failed.
- */
-class JobAddException extends \Exception {}
-
-/**
- * Triggered when a job cannot be found in the queue
- */
-class JobNotFoundException extends \Exception {}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         timeoutForLargeTests="900">
+    <testsuites>
+        <testsuite name="Tests">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">lib</directory>
+            <exclude>
+                <directory>vendor</directory>
+                <directory>build</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/Treffynnon/At/TestableAtWrapper.php
+++ b/tests/Treffynnon/At/TestableAtWrapper.php
@@ -1,0 +1,10 @@
+<?php
+namespace Treffynnon\At\Tests;
+
+use Treffynnon\At\Wrapper as At;
+
+class TestableAtWrapper extends At {
+    public static function getQueueRegex() {
+        return static::$queueRegex;
+    }
+}

--- a/tests/Treffynnon/At/WrapperTest.php
+++ b/tests/Treffynnon/At/WrapperTest.php
@@ -1,8 +1,10 @@
 <?php
-require_once __DIR__ . '/../../../lib/Treffynnon/At/Wrapper.php';
+namespace Treffynnon\At\Tests;
+
+use PHPUnit\Framework\TestCase;
 use Treffynnon\At\Wrapper as At;
 
-class AtWrapperTest extends \PHPUnit_Framework_TestCase {
+class AtWrapperTest extends TestCase {
     protected $test_file = '';
     public function setUp() {
         $this->test_file = tempnam(sys_get_temp_dir(), 'php');
@@ -22,7 +24,7 @@ class AtWrapperTest extends \PHPUnit_Framework_TestCase {
         $this->assertInstanceOf('Treffynnon\At\Job', $obj);
         $this->cleanUpJobs($obj);
     }
-    
+
     public function testAtLq() {
         $this->setDependencies(array('testAtFile','testAtCmd'));
         $job = 'echo "hello" | wall';
@@ -30,7 +32,7 @@ class AtWrapperTest extends \PHPUnit_Framework_TestCase {
         At::cmd($job, $time, 't');
         At::cmd($job, $time, 't');
         $array = At::lq('t');
-        $this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_ARRAY, $array);
+        $this->assertInternalType('array', $array);
         $this->assertGreaterThanOrEqual(2, count($array));
         $this->cleanUpJobs($array);
     }
@@ -49,11 +51,11 @@ class AtWrapperTest extends \PHPUnit_Framework_TestCase {
         }
         $this->assertSame($m, count($test_strings));
     }
-    
+
     public function tearDown() {
         unlink($this->test_file);
     }
-    
+
     private function cleanUpJobs($jobs) {
         if(!is_array($jobs)) {
             $jobs = array($jobs);
@@ -62,14 +64,8 @@ class AtWrapperTest extends \PHPUnit_Framework_TestCase {
             try {
                 $job->rem();
             } catch(JobNotFoundException $e) {
-                
+
             }
         }
-    }
-}
-
-class TestableAtWrapper extends At {
-    public static function getQueueRegex() {
-        return static::$queueRegex;
     }
 }


### PR DESCRIPTION
# Changed log
- Resolves issue #10.
- To define the `PHPUnit: ^4.8` version and it can be compatible with future PHPUnit version easily.
- Split all classes to be single PHP files.
- Removing additional white spaces.
- Creating a `phpunit.xml` and define the `bootstrap` attribute to load `./vendor/autoload.php` file automatically during PHPUnit tests running.